### PR TITLE
minimal install mode

### DIFF
--- a/aptosid/aptosid-bootstrap/main.py
+++ b/aptosid/aptosid-bootstrap/main.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: 2026 Kel Modderman <kelvmod@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+"""Bootstrap a minimal Debian into the target.
+
+The alternative to unpacking the live media's readonly filesystem: debootstrap
+a bare system into the target, hand it the live session's own apt
+configuration, and install nothing beyond essential utilities, a kernel and a
+boot loader.
+
+Everything that shapes the result is read from the running live system - apt
+sources and their keyrings, the kernel metapackage, the initramfs tool, the
+boot loader - so the installed system matches the medium it was installed
+from and no build time state has to be baked into this module.
+
+Mirrors what pyfll does when it builds the live media itself (pyfll/apt.py).
+"""
+
+import os
+import re
+import shutil
+import subprocess
+
+import libcalamares
+
+import gettext
+_ = gettext.translation("calamares-python",
+                        localedir=libcalamares.utils.gettext_path(),
+                        languages=libcalamares.utils.gettext_languages(),
+                        fallback=True).gettext
+
+# apt in a chroot: no recommends (this is a minimal system), no translations,
+# and none of the interactive progress decoration.
+APT_OPTIONS = [
+    "-o", "APT::Install-Recommends=0",
+    "-o", "Acquire::Languages=none",
+    "-o", "Dpkg::Use-Pty=0",
+    "-o", "Dpkg::Progress-Fancy=0",
+    "-o", "APT::Color=0",
+]
+
+# Where the bootloader module's own configuration is found, in search order:
+# /etc takes precedence over the shipped defaults, as it does in calamares.
+BOOTLOADER_CONF = (
+    "/etc/calamares/modules/bootloader.conf",
+    "/usr/share/calamares/modules/bootloader.conf",
+)
+
+# grub's EFI package per architecture; the BIOS case is always grub-pc.
+GRUB_EFI = {
+    "amd64": "grub-efi-amd64",
+    "i386": "grub-efi-ia32",
+    "arm64": "grub-efi-arm64",
+}
+
+status = ""
+
+
+def pretty_name():
+    return _("Bootstrap a minimal Debian system")
+
+
+def pretty_status_message():
+    return status or pretty_name()
+
+
+def report(message, fraction):
+    """Push a status message and progress fraction to the UI."""
+    global status
+    status = message
+    libcalamares.utils.debug(message)
+    libcalamares.job.setprogress(fraction)
+
+
+class OutputProgress:
+    """Show a command's output as the step's status message, creeping the
+    progress bar from *start* towards *end* as lines arrive. Neither
+    debootstrap nor apt report progress usefully, so this is the honest
+    alternative to a bar that sits still for several minutes."""
+
+    def __init__(self, start, end, step=0.002):
+        self.value = start
+        self.end = end
+        self.step = step
+
+    def __call__(self, line):
+        line = line.strip()
+        if not line:
+            return
+        global status
+        status = line
+        self.value = min(self.end, self.value + self.step)
+        libcalamares.job.setprogress(self.value)
+
+
+def host_output(args):
+    """Run a command on the live system, returning its output lines."""
+    lines = []
+    libcalamares.utils.host_env_process_output(args, lines)
+    return lines
+
+
+def host_installed(package):
+    """True when *package* is installed on the live system."""
+    try:
+        lines = host_output(["dpkg-query", "-W", "-f", "${Status}", package])
+    except subprocess.CalledProcessError:
+        return False
+    return "install ok installed" in " ".join(lines)
+
+
+def target_apt(command, packages=None, progress=None):
+    """Run apt-get in the target. Non-interactive: the target's debconf has no
+    terminal to ask questions on."""
+    args = ["env", "DEBIAN_FRONTEND=noninteractive",
+            "apt-get", "--yes", "-q"] + APT_OPTIONS + [command]
+    if packages:
+        args += packages
+    libcalamares.utils.target_env_process_output(args, progress)
+
+
+def deb822_stanzas(path):
+    """Parse a deb822 apt sources file into a list of field mappings.
+
+    Continuation lines are skipped: the only multi-line field pyfll writes is
+    an embedded Signed-by key, which travels with the file when it is copied
+    and needs no further handling here."""
+    stanzas = []
+    fields = {}
+    with open(path) as sources:
+        for line in sources:
+            if not line.strip():
+                if fields:
+                    stanzas.append(fields)
+                    fields = {}
+                continue
+            if line.startswith(("#", " ", "\t")):
+                continue
+            key, _colon, value = line.partition(":")
+            fields[key.strip().lower()] = value.strip()
+    if fields:
+        stanzas.append(fields)
+    return stanzas
+
+
+def live_apt_sources():
+    """Every deb822 stanza configured on the live system."""
+    stanzas = []
+    sources_dir = "/etc/apt/sources.list.d"
+    for name in sorted(os.listdir(sources_dir)):
+        if name.endswith(".sources"):
+            stanzas += deb822_stanzas(os.path.join(sources_dir, name))
+    return stanzas
+
+
+def apt_keyrings(stanzas):
+    """Signed-by keyring files referenced by the live system's apt sources."""
+    keyrings = []
+    for fields in stanzas:
+        for path in fields.get("signed-by", "").split():
+            if os.path.isfile(path) and path not in keyrings:
+                keyrings.append(path)
+    return keyrings
+
+
+def keyring_packages(keyrings):
+    """The archive-keyring packages owning *keyrings*, so that the installed
+    system keeps following archive key rotations by itself."""
+    packages = []
+    for keyring in keyrings:
+        package = re.sub(r"\.(gpg|asc)$", "", os.path.basename(keyring))
+        if package.endswith("-archive-keyring") and package not in packages:
+            packages.append(package)
+    return packages
+
+
+def kernel_metapackage(arch):
+    """The live system's linux-image metapackage, e.g.
+    linux-image-aptosid-amd64: the installed linux-image package that depends
+    on the running kernel's versioned image."""
+    running = "linux-image-" + os.uname().release
+    candidates = []
+    for line in host_output(["dpkg-query", "-W", "-f",
+                             "${Package}|${Status}|${Depends}\n", "linux-image-*"]):
+        package, _bar, rest = line.partition("|")
+        state, _bar, depends = rest.partition("|")
+        if "install ok installed" not in state or package == running:
+            continue
+        if running in depends:
+            return package
+        # versioned images are not metapackages
+        if not re.match(r"linux-image-\d", package):
+            candidates.append(package)
+
+    if candidates:
+        return sorted(candidates, key=len)[0]
+
+    libcalamares.utils.warning(
+        "no linux-image metapackage found on the live system; "
+        "falling back to Debian's linux-image-{}".format(arch))
+    return "linux-image-" + arch
+
+
+def initramfs_package():
+    """The initramfs tool the live system uses, so the target's initrd is
+    built by the same tool the dracut/initramfs module will drive later."""
+    for package in ("dracut", "initramfs-tools"):
+        if host_installed(package):
+            return package
+    libcalamares.utils.warning("no initramfs tool found on the live system")
+    return None
+
+
+def efi_boot_loader():
+    """The loader the bootloader module is configured to install. pyfll bakes
+    the live medium's own loader into that module's configuration at build
+    time, so this is the authoritative answer - and the target needs packages
+    for exactly the loader that module will go on to install."""
+    for path in BOOTLOADER_CONF:
+        if os.path.isfile(path):
+            # load_yaml warns and returns an empty mapping on a broken file
+            loader = libcalamares.utils.load_yaml(path).get("efiBootLoader")
+            if loader:
+                return loader
+    return "grub"
+
+
+def bootloader_packages(arch, efi):
+    """Boot loader packages for the target, mimicking the live media's loader.
+
+    The live medium only needs the EFI binaries (grub-efi-*-bin); the target
+    gets the full package instead, so its maintainer script refreshes the
+    loader on future upgrades. BIOS boot is grub-pc whatever the medium used,
+    since neither systemd-boot nor rEFInd can boot it."""
+    if not efi:
+        return ["grub-pc"]
+    loader = efi_boot_loader()
+    if loader == "systemd-boot":
+        return ["systemd-boot", "systemd-boot-efi"]
+    if loader == "refind":
+        return ["refind"]
+    return [GRUB_EFI.get(arch, GRUB_EFI["amd64"])]
+
+
+def bootstrapper(conf):
+    """The bootstrap tool to use: the first of the preferred tools installed on
+    the live system, unless the configuration names one explicitly."""
+    named = conf.get("bootstrapper", "")
+    if named:
+        return named
+    for tool in ("cdebootstrap", "debootstrap"):
+        if shutil.which(tool):
+            return tool
+    libcalamares.utils.warning("no bootstrap tool installed on the live system")
+    return "debootstrap"
+
+
+def bootstrap_command(tool, conf, arch, suite, mirror, root):
+    """The bootstrapper command line, following pyfll's debbootstrap()."""
+    include = ",".join(conf.get("bootstrapInclude", []))
+    variant = conf.get("variant", "minbase")
+
+    if tool == "mmdebstrap":
+        command = ["mmdebstrap",
+                   "--architectures=" + arch,
+                   "--variant=" + variant,
+                   "--mode=root",
+                   "--format=directory",
+                   "--hook-dir=/usr/share/mmdebstrap/hooks/merged-usr"]
+    elif tool == "cdebootstrap":
+        command = ["cdebootstrap", "--arch=" + arch, "--flavour=minimal"]
+    else:
+        command = ["debootstrap", "--arch=" + arch,
+                   "--variant=" + variant, "--merged-usr"]
+
+    if include:
+        command.append("--include=" + include)
+    command += [suite, root, mirror]
+    return command
+
+
+def prime_apt(root, stanzas):
+    """Give the target the live system's apt configuration: its sources, its
+    pinning and the keyrings those sources are signed by.
+
+    The bootstrapper's own one-line sources.list is dropped - the live media
+    uses deb822 sources exclusively, and keeping both would configure the
+    Debian mirror twice."""
+    for relpath in ("etc/apt/sources.list.d", "etc/apt/preferences.d"):
+        source_dir = os.path.join("/", relpath)
+        if not os.path.isdir(source_dir):
+            continue
+        target_dir = os.path.join(root, relpath)
+        os.makedirs(target_dir, exist_ok=True)
+        for name in sorted(os.listdir(source_dir)):
+            source = os.path.join(source_dir, name)
+            if os.path.isfile(source):
+                shutil.copy2(source, os.path.join(target_dir, name))
+
+    sources_list = os.path.join(root, "etc/apt/sources.list")
+    if os.path.isfile(sources_list):
+        os.unlink(sources_list)
+
+    for keyring in apt_keyrings(stanzas):
+        target_keyring = os.path.join(root, keyring.lstrip("/"))
+        os.makedirs(os.path.dirname(target_keyring), exist_ok=True)
+        shutil.copy2(keyring, target_keyring)
+
+
+def write_resolv_conf(root):
+    """Give the target a resolver while packages are installed into it: apt
+    runs there under chroot, which shares the live session's network but not
+    its /run, so systemd-resolved's stub symlink would dangle. Prefer the
+    upstream servers resolved knows about, else whatever the live system uses
+    (copied, not linked, so the target sees the contents).
+
+    Only for the install itself; the networkcfg module replaces this later with
+    the live system's own /etc/resolv.conf, symlink and all."""
+    for source in ("/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"):
+        if os.path.isfile(source):
+            shutil.copy(source, os.path.join(root, "etc/resolv.conf"))
+            return
+    libcalamares.utils.warning("no resolv.conf to copy into the target")
+
+
+def policy_rc_d(root, deny):
+    """Deny (or allow again) service startup in the target while packages are
+    installed there, as pyfll does for its build chroots: maintainer scripts
+    must not start daemons in a chroot on the live system's behalf."""
+    path = os.path.join(root, "usr/sbin/policy-rc.d")
+    if not deny:
+        if os.path.isfile(path):
+            os.unlink(path)
+        return
+    with open(path, "w") as policy:
+        policy.write("#!/bin/sh\n")
+        policy.write('echo "$0 denied action: $1 $2" >&2\n')
+        policy.write("exit 101\n")
+    os.chmod(path, 0o755)
+
+
+def target_packages(conf, arch, efi):
+    """The full package list for a minimal target: the configured essentials
+    plus the kernel, initramfs tool and boot loader taken from the live
+    system."""
+    packages = conf.get("packages", {})
+    wanted = list(packages.get("essential", []))
+    if efi:
+        wanted += packages.get("efi", [])
+    wanted += packages.get("firmware", [])
+    wanted += packages.get("extra", [])
+
+    wanted.append(kernel_metapackage(arch))
+    initramfs = initramfs_package()
+    if initramfs:
+        wanted.append(initramfs)
+    wanted += bootloader_packages(arch, efi)
+
+    return wanted
+
+
+def run():
+    """Bootstrap the target when a minimal install was chosen."""
+    conf = libcalamares.job.configuration
+    gs = libcalamares.globalstorage
+
+    mode_key = conf.get("modeKey", "packagechooser_installmode")
+    unpack_key = conf.get("unpackKey", "unpackfs")
+    minimal_item = conf.get("minimalItem", "minimal")
+
+    chosen = gs.value(mode_key) if gs.contains(mode_key) else ""
+    minimal = minimal_item in [item.strip() for item in (chosen or "").split(",")]
+
+    # unpackfsc reads this as its "condition", so exactly one of the two runs.
+    gs.insert(unpack_key, not minimal)
+    if not minimal:
+        libcalamares.utils.debug(
+            "live install: leaving the readonly filesystem to unpackfsc")
+        return None
+
+    root = gs.value("rootMountPoint")
+    if not root or not os.path.isdir(root):
+        return (_("Bootstrap failed"),
+                _("There is no mounted target to bootstrap into."))
+
+    if gs.contains("hasInternet") and not gs.value("hasInternet"):
+        return (_("Bootstrap failed"),
+                _("A minimal install downloads all of its packages and needs "
+                  "a working internet connection."))
+
+    efi = gs.value("firmwareType") == "efi"
+
+    try:
+        arch = host_output(["dpkg", "--print-architecture"])[0].strip()
+
+        # the mirror and suite to bootstrap from: whatever the live session
+        # installs its own Debian packages from
+        source = conf.get("bootstrapSource", "debian")
+        stanzas = deb822_stanzas(
+            "/etc/apt/sources.list.d/{}.sources".format(source))
+        mirror = stanzas[0]["uris"].split()[0]
+        suite = stanzas[0]["suites"].split()[0]
+
+        tool = bootstrapper(conf)
+        report(_("Bootstrapping Debian {!s} {!s}...").format(suite, arch), 0.02)
+        libcalamares.utils.host_env_process_output(
+            bootstrap_command(tool, conf, arch, suite, mirror, root),
+            OutputProgress(0.02, 0.55))
+
+        if tool == "cdebootstrap":
+            # cdebootstrap's runlevel helper has no place in an installed system
+            libcalamares.utils.target_env_process_output(
+                ["dpkg", "--purge", "cdebootstrap-helper-rc.d"])
+
+        report(_("Configuring apt in the target system..."), 0.56)
+        stanzas = live_apt_sources()
+        prime_apt(root, stanzas)
+        write_resolv_conf(root)
+
+        policy_rc_d(root, True)
+        try:
+            target_apt("update")
+
+            wanted = keyring_packages(apt_keyrings(stanzas))
+            wanted += target_packages(conf, arch, efi)
+            if "refind" in wanted:
+                # rEFInd's maintainer script must not install itself to the
+                # ESP here; the bootloader module and the aptosid-refind job
+                # own the target's ESP.
+                libcalamares.utils.target_env_process_output(
+                    ["debconf-set-selections"], None,
+                    "refind refind/install_to_esp boolean false\n")
+
+            report(_("Installing the base system..."), 0.6)
+            libcalamares.utils.debug("installing: {!s}".format(" ".join(wanted)))
+            target_apt("install", wanted, OutputProgress(0.6, 0.99))
+        finally:
+            policy_rc_d(root, False)
+    except subprocess.CalledProcessError as error:
+        return (_("Bootstrap failed"),
+                _("The command <code>{!s}</code> returned error code {!s}.")
+                .format(error.cmd, error.returncode))
+    except (OSError, IndexError, KeyError) as error:
+        return (_("Bootstrap failed"), str(error))
+
+    report(_("Bootstrapped a minimal Debian system"), 1.0)
+    return None

--- a/aptosid/aptosid-bootstrap/main.py
+++ b/aptosid/aptosid-bootstrap/main.py
@@ -42,12 +42,33 @@ APT_OPTIONS = [
     "-o", "APT::Color=0",
 ]
 
+# The SSH public key pyfll bakes into the live medium, when one is configured.
+SSH_AUTHORIZED_KEYS = "/var/lib/fll/ssh_authorized_keys"
+
 # Where the bootloader module's own configuration is found, in search order:
 # /etc takes precedence over the shipped defaults, as it does in calamares.
 BOOTLOADER_CONF = (
     "/etc/calamares/modules/bootloader.conf",
     "/usr/share/calamares/modules/bootloader.conf",
 )
+
+# The smallest base each tool can lay down. These are not equivalent:
+# cdebootstrap's "minimal" is Essential plus apt, while minbase is Essential
+# plus Priority: required. The configured package list is padded for the
+# smaller of the two, which is what makes the tools converge - measured against
+# the sid indices, the only required-priority package a minbase has and this
+# list does not pull in is an awk, so gawk is named there. (The archive also
+# marks bsdutils required, but util-linux ships logger(1) these days and the
+# live system does not install it either.)
+#
+# The consequence, and the reason the list is as long as it is: nothing arrives
+# by priority. Anything an installed system needs - login(1), an init, zoneinfo,
+# an editor - is named in the configuration or it is simply absent.
+BASE_ARGS = {
+    "debootstrap": ["--variant=minbase"],
+    "cdebootstrap": ["--flavour=minimal"],
+    "mmdebstrap": ["--variant=minbase"],
+}
 
 # grub's EFI package per architecture; the BIOS case is always grub-pc.
 GRUB_EFI = {
@@ -249,8 +270,11 @@ def bootstrapper(conf):
     """The bootstrap tool to use: the first of the preferred tools installed on
     the live system, unless the configuration names one explicitly."""
     named = conf.get("bootstrapper", "")
-    if named:
+    if named in BASE_ARGS:
         return named
+    if named:
+        libcalamares.utils.warning(
+            "unknown bootstrapper {!s} configured; ignoring it".format(named))
     for tool in ("cdebootstrap", "debootstrap"):
         if shutil.which(tool):
             return tool
@@ -261,21 +285,19 @@ def bootstrapper(conf):
 def bootstrap_command(tool, conf, arch, suite, mirror, root):
     """The bootstrapper command line, following pyfll's debbootstrap()."""
     include = ",".join(conf.get("bootstrapInclude", []))
-    variant = conf.get("variant", "minbase")
 
     if tool == "mmdebstrap":
         command = ["mmdebstrap",
                    "--architectures=" + arch,
-                   "--variant=" + variant,
                    "--mode=root",
                    "--format=directory",
                    "--hook-dir=/usr/share/mmdebstrap/hooks/merged-usr"]
     elif tool == "cdebootstrap":
-        command = ["cdebootstrap", "--arch=" + arch, "--flavour=minimal"]
+        command = ["cdebootstrap", "--arch=" + arch]
     else:
-        command = ["debootstrap", "--arch=" + arch,
-                   "--variant=" + variant, "--merged-usr"]
+        command = ["debootstrap", "--arch=" + arch, "--merged-usr"]
 
+    command += BASE_ARGS[tool]
     if include:
         command.append("--include=" + include)
     command += [suite, root, mirror]
@@ -326,6 +348,32 @@ def write_resolv_conf(root):
     libcalamares.utils.warning("no resolv.conf to copy into the target")
 
 
+def preserve_ssh_authorized_keys(root):
+    """Carry the live medium's baked in SSH public key into the target.
+
+    pyfll bakes a key into /var/lib/fll/ssh_authorized_keys when one is
+    configured, and fll-live-initscripts' fll_sshd installs it for the live
+    user. That initscript is no part of an installed system, so the key goes
+    into the target's /etc/skel instead: the users module creates the account
+    with `useradd -m`, which copies skel and chowns the home directory
+    afterwards, so the new user gets the key whatever they called themselves.
+
+    Root stays out of scope, exactly as on the live medium - sshd's
+    prohibit-password plus sudo cover privileged access."""
+    if not os.path.isfile(SSH_AUTHORIZED_KEYS) or not os.path.getsize(
+            SSH_AUTHORIZED_KEYS):
+        return
+
+    ssh_dir = os.path.join(root, "etc/skel/.ssh")
+    os.makedirs(ssh_dir, exist_ok=True)
+    os.chmod(ssh_dir, 0o700)
+    authorized_keys = os.path.join(ssh_dir, "authorized_keys")
+    shutil.copy(SSH_AUTHORIZED_KEYS, authorized_keys)
+    os.chmod(authorized_keys, 0o600)
+    libcalamares.utils.debug(
+        "preserved the live medium's authorized_keys in the target's /etc/skel")
+
+
 def policy_rc_d(root, deny):
     """Deny (or allow again) service startup in the target while packages are
     installed there, as pyfll does for its build chroots: maintainer scripts
@@ -342,10 +390,10 @@ def policy_rc_d(root, deny):
     os.chmod(path, 0o755)
 
 
-def target_packages(conf, arch, efi):
-    """The full package list for a minimal target: the configured essentials
-    plus the kernel, initramfs tool and boot loader taken from the live
-    system."""
+def target_packages(conf, arch, efi, partitions):
+    """The full package list for a minimal target: the configured essentials,
+    tools for the filesystems it is being installed onto, and the kernel,
+    initramfs tool and boot loader taken from the live system."""
     packages = conf.get("packages", {})
     wanted = list(packages.get("essential", []))
     if efi:
@@ -353,13 +401,29 @@ def target_packages(conf, arch, efi):
     wanted += packages.get("firmware", [])
     wanted += packages.get("extra", [])
 
-    wanted.append(kernel_metapackage(arch))
     initramfs = initramfs_package()
+
+    # Filesystem tools, by the names the partition module puts in globalstorage
+    # (KPMcore's, so fat32 rather than vfat). Without them the installed system
+    # cannot fsck what it was installed onto, and an encrypted one cannot
+    # unlock its root at all. A filesystem with no entry needs no tools.
+    tools = packages.get("filesystems", {})
+    for partition in partitions or []:
+        wanted += tools.get((partition.get("fs") or "").lower(), [])
+    if any(partition.get("luksMapperName") for partition in partitions or []):
+        wanted += packages.get("luks", [])
+        if initramfs == "initramfs-tools":
+            # dracut reads crypttab natively; initramfs-tools needs the hooks
+            wanted.append("cryptsetup-initramfs")
+
+    wanted.append(kernel_metapackage(arch))
     if initramfs:
         wanted.append(initramfs)
     wanted += bootloader_packages(arch, efi)
 
-    return wanted
+    # apt would not mind the duplicates a two-ext4 layout produces, but the
+    # log reads better without them
+    return list(dict.fromkeys(wanted))
 
 
 def run():
@@ -425,7 +489,7 @@ def run():
             target_apt("update")
 
             wanted = keyring_packages(apt_keyrings(stanzas))
-            wanted += target_packages(conf, arch, efi)
+            wanted += target_packages(conf, arch, efi, gs.value("partitions"))
             if "refind" in wanted:
                 # rEFInd's maintainer script must not install itself to the
                 # ESP here; the bootloader module and the aptosid-refind job
@@ -439,6 +503,8 @@ def run():
             target_apt("install", wanted, OutputProgress(0.6, 0.99))
         finally:
             policy_rc_d(root, False)
+
+        preserve_ssh_authorized_keys(root)
     except subprocess.CalledProcessError as error:
         return (_("Bootstrap failed"),
                 _("The command <code>{!s}</code> returned error code {!s}.")

--- a/aptosid/aptosid-bootstrap/module.desc
+++ b/aptosid/aptosid-bootstrap/module.desc
@@ -1,0 +1,5 @@
+---
+type:       "job"
+name:       "aptosid-bootstrap"
+interface:  "python"
+script:     "main.py"

--- a/calamares/modules/aptosid-bootstrap.conf
+++ b/calamares/modules/aptosid-bootstrap.conf
@@ -33,11 +33,15 @@ bootstrapSource: "debian"
 
 # How to bootstrap: "cdebootstrap", "debootstrap" or "mmdebstrap". Left empty,
 # the first of cdebootstrap and debootstrap that is installed is used, matching
-# the package's own "cdebootstrap | debootstrap" dependency. The variant only
-# applies to debootstrap and mmdebstrap; cdebootstrap is always asked for its
-# "minimal" flavour.
+# the package's own "cdebootstrap | debootstrap" dependency.
+#
+# Whichever tool runs, it is asked for Debian's required plus important
+# priority packages - a Debian minimal install with the standard task
+# deselected. That is not a knob: cdebootstrap's smaller "minimal" flavour
+# installs Essential and apt only, which leaves the target with no login(1) and
+# no way in, and even debootstrap's minbase has no e2fsprogs to fsck an ext4
+# root with.
 bootstrapper: ""
-variant: "minbase"
 
 # Packages the bootstrap must include before apt can work in the target,
 # as pyfll includes them when it builds the live media.
@@ -52,8 +56,12 @@ bootstrapInclude:
 # it gets is named here or derived from the live medium (kernel metapackage,
 # initramfs tool, boot loader).
 packages:
-    # A bootstrap has no init, no sudo, no console setup and no networking;
-    # without these the installed system boots into something unusable.
+    # The bootstrap lays down Essential plus apt and stops there, so everything
+    # else an installed system needs is named here rather than arriving by
+    # package priority: an init, login(1), zoneinfo, an awk for maintainer
+    # scripts, whiptail for debconf, a pager, an editor, ip, ping and nftables,
+    # disk tools, log rotation and a cron. systemd-cron instead of cron, which
+    # conflicts with it.
     #
     # NetworkManager rather than a hand-written systemd-networkd file, so a
     # minimal target and one unpacked from the live image run the same network
@@ -70,26 +78,62 @@ packages:
     # takes a polkit authority (polkitd) and logind sessions (libpam-systemd)
     # to ever be true.
     essential:
-        - systemd-sysv
-        - dbus
         - adduser
-        - sudo
-        - locales
         - console-setup
-        - systemd-resolved
-        - systemd-timesyncd
+        - dbus
+        - fdisk
+        - gawk
+        - gdisk
+        - iproute2
+        - iputils-ping
+        - less
+        - libpam-systemd
         - linux-sysctl-defaults
+        - locales
+        - login
+        - logrotate
+        - nano
         - network-manager
         - network-manager-tui
-        - wpasupplicant
-        - wireless-regdb
+        - nftables
+        - openssh-server
         - polkitd
-        - libpam-systemd
+        - sudo
+        - systemd-cron
+        - systemd-resolved
+        - systemd-sysv
+        - systemd-timesyncd
+        - tzdata
+        - whiptail
+        - wireless-regdb
+        - wpasupplicant
 
     # Added when the target boots via EFI; the bootloader module runs
     # efibootmgr in the target to register the loader.
     efi:
         - efibootmgr
+
+    # Userspace tools per filesystem the target is installed onto, keyed by the
+    # names the partition module writes to globalstorage - KPMcore's, so fat32
+    # rather than vfat - and only for the filesystems in use. The list covers
+    # what can actually end up on a target: partition.conf offers ext4, btrfs
+    # and xfs, and pins the EFI system partition to fat32. Swap needs nothing.
+    #
+    # ext4's tools come with the base already (e2fsprogs is priority important)
+    # and it is named for the same reason login is. dosfstools is not
+    # cosmetic either: the fstab module gives the ESP passno 2, so an EFI
+    # install runs fsck.vfat on it at every boot.
+    filesystems:
+        ext4:   [ e2fsprogs ]
+        btrfs:  [ btrfs-progs ]
+        xfs:    [ xfsprogs ]
+        fat32:  [ dosfstools ]
+
+    # Added when any target partition is encrypted. cryptsetup-initramfs is
+    # appended too on initramfs-tools media, which cannot unlock a root
+    # filesystem without its hooks; dracut reads crypttab natively.
+    luks:
+        - cryptsetup
 
     # Firmware and CPU microcode, off by default: a minimal install stays
     # minimal, and these are only needed by specific hardware. Populate with

--- a/calamares/modules/aptosid-bootstrap.conf
+++ b/calamares/modules/aptosid-bootstrap.conf
@@ -1,0 +1,100 @@
+# Bootstrap a minimal Debian into the target, instead of unpacking the live
+# media's readonly filesystem.
+#
+# The module reads the install mode chosen on the packagechooser@installmode
+# page from globalstorage. For the "minimal" item it debootstraps the target,
+# hands it the live session's apt sources and keyrings, and installs the
+# essentials below plus the kernel, initramfs tool and boot loader the live
+# medium itself is using. For any other choice it does nothing at all.
+#
+# It also writes the globalstorage flag that unpackfsc reads as its
+# "condition", so exactly one of the two ever runs; it must therefore stay
+# sequenced before unpackfsc, and stay in the sequence even where only live
+# installs are offered (a missing flag means "unpack", so removing the
+# packagechooser page is enough to disable minimal installs).
+---
+# Where the install mode comes from: globalstorage key (packagechooser writes
+# "packagechooser_" plus its instance id) and the item id that asks for a
+# bootstrapped system.
+modeKey: "packagechooser_installmode"
+minimalItem: "minimal"
+
+# The globalstorage flag consumed by unpackfsc's "condition": false once this
+# module has bootstrapped the target, true for a live install.
+unpackKey: "unpackfs"
+
+# Name of the live system's deb822 apt source to bootstrap from, i.e.
+# /etc/apt/sources.list.d/<bootstrapSource>.sources; its first URIs and Suites
+# entry become the mirror and suite. pyfll names these files after the
+# repository, so Debian's is debian.sources. All of the live system's sources
+# are copied into the target afterwards, this one only decides where the
+# bootstrap itself is fetched from.
+bootstrapSource: "debian"
+
+# How to bootstrap: "cdebootstrap", "debootstrap" or "mmdebstrap". Left empty,
+# the first of cdebootstrap and debootstrap that is installed is used, matching
+# the package's own "cdebootstrap | debootstrap" dependency. The variant only
+# applies to debootstrap and mmdebstrap; cdebootstrap is always asked for its
+# "minimal" flavour.
+bootstrapper: ""
+variant: "minbase"
+
+# Packages the bootstrap must include before apt can work in the target,
+# as pyfll includes them when it builds the live media.
+bootstrapInclude:
+    - apt-utils
+    - ca-certificates
+    - gnupg
+    - xz-utils
+    - zstd
+
+# Recommends are off, so a minimal install really is minimal and everything
+# it gets is named here or derived from the live medium (kernel metapackage,
+# initramfs tool, boot loader).
+packages:
+    # A bootstrap has no init, no sudo, no console setup and no networking;
+    # without these the installed system boots into something unusable.
+    #
+    # NetworkManager rather than a hand-written systemd-networkd file, so a
+    # minimal target and one unpacked from the live image run the same network
+    # stack: wired DHCP needs no configuration at all, and the networkcfg
+    # module later copies the live session's own connections (wireless
+    # credentials included) into the target, which it only does when
+    # NetworkManager is installed there.
+    #
+    # Its wireless support, nmtui and the regulatory database are only
+    # Recommends, so they are named here - recommends are off. So are polkitd
+    # and libpam-systemd, which this needs too: the users module puts the new
+    # user in netdev and sudo, and Debian's NetworkManager polkit rule only
+    # lets those groups manage connections for a local, active session, which
+    # takes a polkit authority (polkitd) and logind sessions (libpam-systemd)
+    # to ever be true.
+    essential:
+        - systemd-sysv
+        - dbus
+        - adduser
+        - sudo
+        - locales
+        - console-setup
+        - systemd-resolved
+        - systemd-timesyncd
+        - linux-sysctl-defaults
+        - network-manager
+        - network-manager-tui
+        - wpasupplicant
+        - wireless-regdb
+        - polkitd
+        - libpam-systemd
+
+    # Added when the target boots via EFI; the bootloader module runs
+    # efibootmgr in the target to register the loader.
+    efi:
+        - efibootmgr
+
+    # Firmware and CPU microcode, off by default: a minimal install stays
+    # minimal, and these are only needed by specific hardware. Populate with
+    # e.g. firmware-linux-nonfree, amd64-microcode, intel-microcode.
+    firmware: []
+
+    # Anything else this medium should put on a minimal target.
+    extra: []

--- a/calamares/modules/packagechooser_installmode.conf
+++ b/calamares/modules/packagechooser_installmode.conf
@@ -13,15 +13,21 @@ default: live
 labels:
     step: "Install mode"
 
+# Each item names its own artwork, resolved against the branding component
+# directory. Without one the page falls back to calamares' own "no selection"
+# placeholder, which looks like a broken image; fred with the wordmark stands
+# for the full system, the bare wordmark for the stripped down one.
 items:
   - id: live
     name: "Full aptosid system"
+    screenshot: "aptosid2.png"
     description: "Copy the running live system to disk: the complete aptosid
         desktop, exactly as it was booted, with all of its applications. Works
         without a network connection."
 
   - id: minimal
     name: "Minimal Debian system"
+    screenshot: "aptosid.png"
     description: "Install a minimal Debian instead: base system, kernel and
         boot loader, with the same package sources and kernel as this medium,
         but no desktop and no applications. All packages are downloaded, so

--- a/calamares/modules/packagechooser_installmode.conf
+++ b/calamares/modules/packagechooser_installmode.conf
@@ -1,0 +1,28 @@
+# Install mode: copy the live system, or bootstrap a minimal Debian.
+#
+# The "legacy" method writes the chosen item id to globalstorage as
+# packagechooser_<instance id>, i.e. packagechooser_installmode. Nothing is
+# installed from here; the aptosid-bootstrap job module reads that key in the
+# exec phase and either leaves the live filesystem to unpackfsc or bootstraps
+# the target instead.
+---
+mode: required
+method: legacy
+default: live
+
+labels:
+    step: "Install mode"
+
+items:
+  - id: live
+    name: "Full aptosid system"
+    description: "Copy the running live system to disk: the complete aptosid
+        desktop, exactly as it was booted, with all of its applications. Works
+        without a network connection."
+
+  - id: minimal
+    name: "Minimal Debian system"
+    description: "Install a minimal Debian instead: base system, kernel and
+        boot loader, with the same package sources and kernel as this medium,
+        but no desktop and no applications. All packages are downloaded, so
+        this needs a working internet connection and takes longer."

--- a/calamares/modules/packages.conf
+++ b/calamares/modules/packages.conf
@@ -202,8 +202,12 @@ pacman:
 # "binutils", and then a second time for "wget". When installing large numbers
 # of packages, this can lead to a considerable time savings.
 #
+# The live-image packages below are removed one by one, tolerating failure:
+# a target that was bootstrapped rather than unpacked from the live image
+# (see the aptosid-bootstrap module) never had them installed, and a "remove"
+# operation fails as a whole when apt cannot find one of its packages.
 operations:
-  - remove:
+  - try_remove:
       - 'calamares-settings-aptosid'
       - 'calamares'
       - 'distro-defaults'

--- a/calamares/modules/shellprocess_desktop.conf
+++ b/calamares/modules/shellprocess_desktop.conf
@@ -10,8 +10,12 @@ dontChroot: true
 timeout: 300
 
 script:
-    # sync the live skel so first-login desktop configuration matches
-    - "- rsync -a /etc/skel/. ${ROOT}/etc/skel/."
+    # sync the live skel so first-login desktop configuration matches. Only for
+    # a target unpacked from the live image: /etc/default/distro comes with that
+    # image (the cleanup module drops it at the very end of the install), and is
+    # absent from a target the aptosid-bootstrap module bootstrapped, which has
+    # no desktop for the live session's configuration to apply to.
+    - "- test -e ${ROOT}/etc/default/distro && rsync -a /etc/skel/. ${ROOT}/etc/skel/."
 
 i18n:
     name: "Apply aptosid desktop configuration"

--- a/calamares/modules/unpackfsc.conf
+++ b/calamares/modules/unpackfsc.conf
@@ -72,4 +72,7 @@
 source: "/run/fll/FLL_READONLY_FSTYPE"
 sourcefs: "FLL_READONLY_FSTYPE"
 destination: "/"
-# condition: true
+# Set by the aptosid-bootstrap module, which runs just before this one: false
+# once it has bootstrapped a minimal Debian into the target. An unset value
+# counts as true, so unpacking stays the default.
+condition: "unpackfs"

--- a/calamares/modules/welcome.conf
+++ b/calamares/modules/welcome.conf
@@ -43,7 +43,10 @@ requirements:
     # distribution domain.
     #
     # The URL is only used if "internet" is in the *check* list below.
-    #internetCheckUrl:   http://example.com
+    # Plain http on purpose: a live session's clock can be far enough out to
+    # make certificate validation fail, which would report a working
+    # connection as broken.
+    internetCheckUrl:   http://aptosid.com
     #
     # This may be a single URL, or a list or URLs, in which case the
     # URLs will be checked one-by-one; if any of them returns data,
@@ -79,10 +82,14 @@ requirements:
     #   at least three times ("what I tell you three times is true").
     # Keep in mind that "true" and "false" are YAML keywords for
     # boolean values, so should be quoted.
+    # internet is checked, but not required: a live install needs no network,
+    # while a minimal install downloads everything. aptosid-bootstrap reads the
+    # result (hasInternet) and refuses to bootstrap without a connection.
     check:
         - storage
         - ram
         - power
+        - internet
         - root
     # List conditions that **must** be satisfied (from the list
     # of conditions, above) for installation to proceed.

--- a/calamares/settings.conf
+++ b/calamares/settings.conf
@@ -10,6 +10,7 @@ modules-search: [ local, /usr/lib/calamares/modules ]
 # sequence below. This breaks the former monolithic aptosid-config helper
 # into small, individually-configurable units.
 instances:
+- { id: installmode, module: packagechooser, config: packagechooser_installmode.conf }
 - { id: desktop, module: shellprocess,  config: shellprocess_desktop.conf }
 - { id: greetd,  module: shellprocess,  config: shellprocess_greetd.conf  }
 - { id: xdg,     module: preservefiles,  config: preservefiles_xdg.conf    }
@@ -62,6 +63,7 @@ sequence:
 # Jobs should be executed sparingly (if at all) in this phase.
 - show:
   - welcome
+  - packagechooser@installmode
   - locale
   - keyboard
   - partition
@@ -77,6 +79,9 @@ sequence:
 - exec:
   - partition
   - mount
+  # aptosid-bootstrap decides which of the two fills the target: it bootstraps
+  # a minimal Debian itself, or leaves the live filesystem to unpackfsc
+  - aptosid-bootstrap
   - unpackfsc
   - luksbootkeyfile
   - machineid

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,33 @@ calamares-settings-aptosid (20260803.1) UNRELEASED; urgency=medium
     target bootstrapped by the new aptosid-bootstrap module never had
     them installed, and a whole 'remove' operation fails when apt cannot
     find one of its packages.
+  * New 'Install mode' page: as well as installing the live system,
+    calamares can now bootstrap a minimal Debian onto the target instead
+    - base system, kernel, boot loader and NetworkManager, no desktop.
+    It takes this medium's own package sources, keyrings and kernel, so
+    the result matches the medium it came from, and it needs an internet
+    connection.
+  * aptosid-bootstrap: the new job module doing that work, with
+    cdebootstrap or debootstrap. It primes apt in the target from the
+    live session's own sources, adds tools for the filesystems the
+    target is installed onto (and cryptsetup for an encrypted one), and
+    sets the flag unpackfsc now reads as its condition, so a target is
+    either unpacked from the live image or bootstrapped, never both.
+  * aptosid-bootstrap: name every package a minimal target needs instead
+    of leaning on package priorities. A bootstrap lays down essential
+    plus apt and stops, so login, tzdata, an awk, an editor and the rest
+    are listed explicitly; without login the console asked for a user
+    name and never for a password.
+  * aptosid-bootstrap: keep the medium's SSH public key (pyfll's
+    ssh_authorized_keys) in the target's /etc/skel, so the user the
+    installer creates can log in over ssh just as on the live system.
+  * welcome: check for an internet connection, via http://aptosid.com
+    over plain http so a live session's clock cannot break the check. It
+    is checked but not required - only a minimal install needs it.
+  * shellprocess_desktop: only copy the live /etc/skel onto a target
+    unpacked from the live image; a bootstrapped one has no desktop to
+    configure.
+  * depend on cdebootstrap | debootstrap.
 
  -- Kel Modderman <kelvmod@gmail.com>  Mon, 03 Aug 2026 19:19:59 +1000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,15 @@
-calamares-settings-aptosid (20260718.2) UNRELEASED; urgency=medium
+calamares-settings-aptosid (20260803.1) UNRELEASED; urgency=medium
 
+  [ Stefan Lippers-Hollmann ]
   * NOT RELEASED YET
 
- -- Stefan Lippers-Hollmann <s.l-h@gmx.de>  Tue, 21 Jul 2026 21:34:58 +0200
+  [ Kel Modderman ]
+  * packages: tolerate failure when removing the live image packages; a
+    target bootstrapped by the new aptosid-bootstrap module never had
+    them installed, and a whole 'remove' operation fails when apt cannot
+    find one of its packages.
+
+ -- Kel Modderman <kelvmod@gmail.com>  Mon, 03 Aug 2026 19:19:59 +1000
 
 calamares-settings-aptosid (20260718.1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Vcs-Browser: https://github.com/fullstory/calamares-settings-aptosid
 Package: calamares-settings-aptosid
 Architecture: all
 Depends: calamares,
+	cdebootstrap | debootstrap,
 	cracklib-runtime,
 	pkexec,
 	python3,
@@ -30,3 +31,7 @@ Description: aptosid theme and settings for the Calamares Installer
  By default, it contains a set of boilerplate wording and images. This
  package provides the latest aptosid artwork as well as scripts that
  support EFI installations.
+ .
+ Next to installing the live system itself, it can bootstrap a minimal
+ Debian onto the target instead: base system, kernel and boot loader,
+ using this medium's own package sources.

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 calamares etc
+aptosid/aptosid-bootstrap usr/lib/calamares/modules
 aptosid/aptosid-refind usr/lib/calamares/modules
 aptosid/helpers usr/share/calamares
 aptosid/calamares-install-aptosid usr/libexec


### PR DESCRIPTION
The PR adds a choice to the calamares installer: standard or minimal. The difference between them; standard mode unpacks the read only live media chroot filesystem to the installation target, the minimal mode bootstraps a minimal system, essential utilities, network-manager and openssh-server instead.